### PR TITLE
Merges the three .gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 bin/
 .idea/
 cmake-build-debug/
+.kdev4/
+*.kdev4
+build/

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,3 +1,0 @@
-.kdev4/
-*.kdev4
-build/

--- a/warm_up/.gitignore
+++ b/warm_up/.gitignore
@@ -1,3 +1,0 @@
-.kdev4/
-*.kdev4
-build/


### PR DESCRIPTION
There was still one lying around in the core directory, as well as one
in the warm_up directory. Those have been merged into the one in the
project root in order to make it more clear, which files are actually
ignored.